### PR TITLE
41 Add installation popup and configure initial settings

### DIFF
--- a/src/installed.html
+++ b/src/installed.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Shortcut Assistant</title>
+    <link href="styles/tailwind.min.css" rel="stylesheet">
+    <script src="js/tailwind.5"></script>
+    <style>
+        body {
+            width: 300px; /* Adjust as needed */
+            height: 150px; /* Adjust as needed */
+        }
+    </style>
+</head>
+<body class="bg-gray-800 text-white p-4">
+
+<div class="flex flex-col items-center justify-center h-screen">
+    <h1 class="text-5xl font-extrabold dark:text-white text-center ">Shortcut Assistant</h1>
+    <br>
+    <p class="text-center md">
+        Welcome to Shortcut Assistant! This extension is designed to help you work more efficiently in Shortcut.<br>
+        In the popup window, accessible by clicking the Shortcut Assistant icon in the top right of your browser,
+        you can add notes to stories, analyze stories with our GPT, and configure settings. <br>You can provide your
+        own OpenAI API token or authenticate using your Google account.<br> Todoist shortcuts are disabled by default
+        but can be enabled in the settings tab as well. </p>
+</div>
+
+</body>
+
+</html>
+

--- a/src/js/service_worker.js
+++ b/src/js/service_worker.js
@@ -135,6 +135,19 @@ if (typeof self !== 'undefined' && self instanceof ServiceWorkerGlobalScope) {
         }
     });
 
+    chrome.runtime.onInstalled.addListener(function(details) {
+        if (details.reason === "install") {
+            chrome.windows.create({
+                url: '../installed.html',
+                type: 'popup',
+                width: 310,
+                height: 500
+            });
+        }
+        chrome.storage.sync.set({'enableStalledWorkWarnings': true});
+        chrome.storage.sync.set({'enableTodoistOptions': false});
+    });
+
 
     chrome.tabs.onUpdated.addListener(async function
             (tabId, changeInfo, tab) {


### PR DESCRIPTION
Created a new file, 'installed.html', to serve as an installation popup. This file will provide a welcome message and some basic extension information upon installation. Also modified 'service_worker.js' to handle this new process, opening the popup window when the extension is installed. Default settings ('enableStalledWorkWarnings' and 'enableTodoistOptions') are now set during installation.