### PR TITLE
SHA-147L Add ability to customise workflow states

### DIFF
--- a/jest.chromeSetup.js
+++ b/jest.chromeSetup.js
@@ -35,13 +35,17 @@ global.chrome = {
     sync: {
       set: jest.fn().mockResolvedValue({}),
       get: jest.fn((key, callback) => {
-        callback({[key]: 'expectedValue'})
+        if (typeof callback === 'function') {
+          callback({[key]: 'expectedValue'})
+        }
       })
     },
     session: {
       set: jest.fn().mockResolvedValue({}),
       get: jest.fn((key, callback) => {
-        callback({[key]: 'expectedValue'})
+        if (typeof callback === 'function') {
+          callback({[key]: 'expectedValue'})
+        }
       })
     }
   },

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -51,6 +51,24 @@
             <span class="label-text">&nbsp;Todoist Shortcuts</span>
         </label>
     </div>
+    <div class="flex form-control"  style="margin-bottom: 10px" >
+        <label for="todoistOptions" class="text-white">
+        <input type="text" id="inDevelopmentText" class="input input-sm input-bordered flex">
+            <span class="label-text">In Development State</span>
+        </label>
+    </div>
+    <div class="flex form-control"  style="margin-bottom: 10px" >
+        <label for="todoistOptions" class="text-white">
+        <input type="text" id="inReviewText" class="input input-sm input-bordered flex">
+            <span class="label-text">In Review State</span>
+        </label>
+    </div>
+    <div class="flex form-control"  style="margin-bottom: 10px" >
+        <label for="todoistOptions" class="text-white">
+        <input type="text" id="completedText" class="input input-sm input-bordered flex">
+            <span class="label-text">Completed State</span>
+        </label>
+    </div>
     <div class="flex items-center">
         <input id="openAIToken" type="password" class="input input-sm input-bordered flex mr-4 mb-2" placeholder="OpenAI API Key">
         <div class="text-right">

--- a/src/html/updated.html
+++ b/src/html/updated.html
@@ -15,14 +15,11 @@
 <body class="text-white p-4">
 
 <div class="flex flex-col items-center justify-center">
-    <h1 class="text-2xl font-bold dark:text-white text-center ">Shortcut Assistant: v2.4.4</h1>
+    <h1 class="text-2xl font-bold dark:text-white text-center ">Shortcut Assistant: v2.5.0</h1>
     <br>
     <div class="items-center justify-center mb-4">
         <ol class="list-disc list-inside">
-            <li class="pb-1">Updates following Shortcut design changes restore functionality</li>
-            <li class="pb-1">Ctrl + Shift + S now sets your cursor to enter the story state.</li>
-            <li class="pb-1">Ctrl + Shift + I sets your cursor to enter the story iteration.</li>
-            <li class="pb-1">Ctrl + Shift + E sets your cursor to enter the story estimate (press a number after that to set the estimate).</li>
+            <li class="pb-1">You can now set the names of your workflow states if they've been customized</li>
             </li>
         </ol>
     </div>

--- a/src/js/cycle-time/cycle-time.ts
+++ b/src/js/cycle-time/cycle-time.ts
@@ -1,6 +1,7 @@
-import {hoursBetweenExcludingWeekends} from '../utils/hours-between-excluding-weekends'
-import {Story} from '../utils/story'
-import storyPageIsReady from '../utils/story-page-is-ready'
+import {getSyncedSetting} from '@sx/utils/get-synced-setting'
+import {hoursBetweenExcludingWeekends} from '@sx/utils/hours-between-excluding-weekends'
+import {Story} from '@sx/utils/story'
+import storyPageIsReady from '@sx/utils/story-page-is-ready'
 
 
 export class CycleTime {
@@ -15,12 +16,14 @@ export class CycleTime {
   static async set() {
     await storyPageIsReady()
     this.clear()
-    const isCompleted = Story.isInState('Completed')
+    const doneText = await getSyncedSetting('doneText', 'Completed')
+    const isCompleted = Story.isInState(doneText)
     if (!isCompleted) {
       return
     }
     const createdDiv = document.querySelector('.story-date-created')
-    const inDevelopmentDateString = Story.getDateInState('In Development')
+    const inDevelopmentText = await getSyncedSetting('inDevelopmentText', 'In Development')
+    const inDevelopmentDateString = Story.getDateInState(inDevelopmentText)
     const completedDiv = document.querySelector('.story-date-completed')
     const completedValue = completedDiv?.querySelector('.value')
     const completedDateString = completedValue?.innerHTML

--- a/src/js/development-time/development-time.ts
+++ b/src/js/development-time/development-time.ts
@@ -1,5 +1,6 @@
-import {Story} from '../utils/story'
-import storyPageIsReady from '../utils/story-page-is-ready'
+import {getSyncedSetting} from '@sx/utils/get-synced-setting'
+import {Story} from '@sx/utils/story'
+import storyPageIsReady from '@sx/utils/story-page-is-ready'
 
 
 export class DevelopmentTime {
@@ -26,20 +27,22 @@ export class DevelopmentTime {
   static async set() {
     await storyPageIsReady()
     this.remove()
-    const inDevelopment = Story.isInState('In Development')
-    const inReview = Story.isInState('Ready for Review')
+    const inDevelopmentText = await getSyncedSetting('inDevelopmentText', 'In Development')
+    const inReviewText = await getSyncedSetting('inReviewText', 'Ready for Review')
+    const inDevelopment = Story.isInState(inDevelopmentText)
+    const inReview = Story.isInState(inReviewText)
     if (!inDevelopment && !inReview) {
       return
     }
 
     if (inDevelopment) {
-      const hoursElapsed = Story.getTimeInState('In Development')
+      const hoursElapsed = Story.getTimeInState(<string>inDevelopmentText)
       if (hoursElapsed) {
         this.setTimeSpan(hoursElapsed)
       }
     }
     if (inReview) {
-      const hoursElapsed = Story.getTimeInState('Ready for Review')
+      const hoursElapsed = Story.getTimeInState(inReviewText)
       if (hoursElapsed) {
         this.setTimeSpan(hoursElapsed)
       }

--- a/src/js/keyboard-shortcuts/change-state.ts
+++ b/src/js/keyboard-shortcuts/change-state.ts
@@ -1,4 +1,4 @@
-import sleep from '../utils/sleep'
+import sleep from '@sx/utils/sleep'
 
 
 async function changeState(): Promise<void> {

--- a/src/js/keyboard-shortcuts/copy-branch-move-to-in-development.ts
+++ b/src/js/keyboard-shortcuts/copy-branch-move-to-in-development.ts
@@ -1,8 +1,10 @@
-import {getStateDiv} from '../utils/get-state-div'
-import sleep from '../utils/sleep'
+import {getStateDiv} from '@sx/utils/get-state-div'
+import {getSyncedSetting} from '@sx/utils/get-synced-setting'
+import sleep from '@sx/utils/sleep'
 
 import changeState from './change-state'
 import copyGitBranch from './copy-git-branch'
+
 
 
 async function copyBranchAndMoveToInDevelopment(): Promise<void> {
@@ -10,7 +12,8 @@ async function copyBranchAndMoveToInDevelopment(): Promise<void> {
   await copyGitBranch(false)
   await changeState()
   await sleep(300)
-  const stateDiv = getStateDiv('In Development')
+  const inDevelopmentText = await getSyncedSetting('inDevelopmentText', 'In Development')
+  const stateDiv = getStateDiv(inDevelopmentText)
   if (stateDiv) {
     stateDiv.click()
   }

--- a/src/js/popup/popup.ts
+++ b/src/js/popup/popup.ts
@@ -130,7 +130,7 @@ export class Popup {
 
     this.inReviewText.value = await getSyncedSetting('inReviewText', 'Ready for Review')
 
-    this.completedText.value = await getSyncedSetting('completedText', 'Done')
+    this.completedText.value = await getSyncedSetting('completedText', 'Completed')
   }
 
   async popupLoaded() {

--- a/src/js/todoist/todoist.ts
+++ b/src/js/todoist/todoist.ts
@@ -1,5 +1,3 @@
-import {sleep} from 'openai/core'
-
 import {logError} from '@sx/utils/log-error'
 import {Story} from '@sx/utils/story'
 

--- a/src/js/utils/get-synced-setting.ts
+++ b/src/js/utils/get-synced-setting.ts
@@ -1,4 +1,6 @@
-export async function getSyncedSetting(setting: string, defaultValue: string | boolean | undefined): Promise<string | undefined> {
+type settingValue = string | number | boolean | undefined
+
+export async function getSyncedSetting<T>(setting: string, defaultValue: T | undefined): Promise<T extends undefined ? settingValue : T> {
   try {
     const result = await chrome.storage.sync.get(setting)
     const {[setting]: value = defaultValue} = result

--- a/tests/development-time/development-time.test.ts
+++ b/tests/development-time/development-time.test.ts
@@ -1,8 +1,19 @@
-import {DevelopmentTime} from '../../src/js/development-time/development-time'
-import {Story} from '../../src/js/utils/story'
+import {DevelopmentTime} from '@sx/development-time/development-time'
+import {Story} from '@sx/utils/story'
 
 
-jest.mock('../../src/js/utils/story-page-is-ready', () => jest.fn().mockResolvedValue(true))
+jest.mock('@sx/utils/story-page-is-ready', () => jest.fn().mockResolvedValue(true))
+
+global.chrome.storage.sync = {get: jest.fn()} as unknown as jest.Mocked<typeof chrome.storage.sync>
+
+// @ts-expect-error - TS doesn't know about the mock implementation
+global.chrome.storage.sync.get.mockImplementation((key, callback) => {
+  const data = {inDevelopmentText: 'In Development'}
+  if (typeof callback === 'function') {
+    callback(data)
+  }
+  return data
+})
 
 
 describe('DevelopmentTime.setTimeSpan', () => {
@@ -18,28 +29,31 @@ describe('DevelopmentTime.setTimeSpan', () => {
   })
 
   it('appends a correctly formatted time span for positive hours', () => {
-    const mockElement = {appendChild: jest.fn()}
+    const mockElement = {appendChild: jest.fn()} as unknown as HTMLElement
     jest.spyOn(Story, 'state', 'get').mockReturnValue(mockElement)
     const hoursElapsed = 48 // 2 days
     DevelopmentTime.setTimeSpan(hoursElapsed)
+    // @ts-expect-error - TS doesn't know about mockElement
     const timeSpan = mockElement.appendChild.mock.calls[0][0]
     expect(timeSpan.innerHTML).toBe(' (2.00 days)')
   })
 
   it('appends a correctly formatted time span for negative hours', () => {
-    const mockElement = {appendChild: jest.fn()}
+    const mockElement = {appendChild: jest.fn()} as unknown as HTMLElement
     jest.spyOn(Story, 'state', 'get').mockReturnValue(mockElement)
     const hoursElapsed = -72 // -3 days, but should be 3 days after abs
     DevelopmentTime.setTimeSpan(hoursElapsed)
+    // @ts-expect-error - TS doesn't know about mockElement
     const timeSpan = mockElement.appendChild.mock.calls[0][0]
     expect(timeSpan.innerHTML).toBe(' (3.00 days)')
   })
 
   it('appends a correctly formatted time span for zero hours', () => {
-    const mockElement = {appendChild: jest.fn()}
+    const mockElement = {appendChild: jest.fn()} as unknown as HTMLElement
     jest.spyOn(Story, 'state', 'get').mockReturnValue(mockElement)
     const hoursElapsed = 0
     DevelopmentTime.setTimeSpan(hoursElapsed)
+    // @ts-expect-error - TS doesn't know about mockElement
     const timeSpan = mockElement.appendChild.mock.calls[0][0]
     expect(timeSpan.innerHTML).toBe(' (0.00 days)')
   })

--- a/tests/popup/initializer.test.ts
+++ b/tests/popup/initializer.test.ts
@@ -1,10 +1,10 @@
-jest.mock('../../src/js/popup/popup', () => {
+jest.mock('@sx/popup/popup', () => {
   return {
     Popup: jest.fn().mockImplementation(() => {})
   }
 })
 
-import {Popup} from '../../src/js/popup/popup'
+import {Popup} from '@sx/popup/popup'
 
 
 describe('Popup Initializer', () => {
@@ -14,14 +14,15 @@ describe('Popup Initializer', () => {
 
   it('should add DOM event listener', () => {
     const addEventListenerSpy = jest.spyOn(document, 'addEventListener')
-    require('../../src/js/popup/initializer')
+    require('@sx/popup/initializer')
     expect(addEventListenerSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function))
   })
 
   it('should instantiate Popup class on DOM content loaded', () => {
     document.addEventListener = jest.fn((event, callback) => {
       if (event === 'DOMContentLoaded') {
-        callback()
+        // @ts-expect-error - TS doesn't know about the mock implementation
+        if(typeof callback === 'function') callback()
       }
     })
     document.dispatchEvent(new Event('DOMContentLoaded'))

--- a/tests/popup/notes-popup.test.ts
+++ b/tests/popup/notes-popup.test.ts
@@ -1,13 +1,15 @@
-import {NotesPopup} from '../../src/js/popup/notes-popup'
-import {Story} from '../../src/js/utils/story'
+import {NotesPopup} from '@sx/popup/notes-popup'
+import {Story} from '@sx/utils/story'
 
 
-jest.mock('../../src/js/utils/story', () => ({
+jest.mock('@sx/utils/story', () => ({
   Story: {
     id: jest.fn()
   }
 }))
-jest.mock('../../src/js/utils/sleep', () => jest.fn(() => Promise.resolve()))
+const mockedStory = Story as jest.Mocked<typeof Story>
+
+jest.mock('@sx/utils/sleep', () => jest.fn(() => Promise.resolve()))
 
 
 const mockElement = (options = {}) => {
@@ -25,7 +27,8 @@ const mockElement = (options = {}) => {
 
 
 describe('NotesPopup', () => {
-  let inputElement
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let inputElement: HTMLInputElement
 
   beforeEach(() => {
     document.body.innerHTML = `
@@ -36,10 +39,11 @@ describe('NotesPopup', () => {
     global.chrome.storage.sync.set = jest.fn(() => Promise.resolve())
     global.chrome.storage.sync.get = jest.fn(() => Promise.resolve({}))
     global.chrome.runtime.onMessage.addListener = jest.fn()
-    inputElement = document.getElementById('storyNotes')
+    inputElement = <HTMLInputElement>document.getElementById('storyNotes')
   })
 
   it('attaches click event listener to saveButton on instantiation', () => {
+    // @ts-expect-error - TS doesn't know about the mock implementation
     const addEventListenerSpy = jest.spyOn(document.getElementById('saveButton'), 'addEventListener')
     new NotesPopup()
     expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function))
@@ -51,32 +55,41 @@ describe('NotesPopup', () => {
   })
 
   it('saves note and updates button text correctly', async () => {
-    Story.id.mockResolvedValue('123')
+    mockedStory.id.mockResolvedValue('123')
     const popup = new NotesPopup()
+    // @ts-expect-error - TS doesn't know about _textContent
     popup.saveButton = {
+      // @ts-expect-error - TS doesn't know about disabled
       disabled: false,
       get textContent() {
+        // @ts-expect-error - TS doesn't know about _textContent
         return this._textContent
       },
       set textContent(value) {
+        // @ts-expect-error - TS doesn't know about _textContent
         this._textContent = value
+        // @ts-expect-error - TS doesn't know about textChanges
         this.textChanges.push(value)
       },
       textChanges: []
     }
-    const storyNotesInput = document.getElementById('storyNotes')
+    const storyNotesInput = <HTMLInputElement>document.getElementById('storyNotes')
     storyNotesInput.value = 'Test note'
     await popup.save()
     expect(global.chrome.storage.sync.set).toHaveBeenCalledWith({'notes_123': 'Test note'})
+    // @ts-expect-error - Migrating from JS
     expect(popup.saveButton.textChanges).toContain('Saved!')
+    // @ts-expect-error - Migrating from JS
     expect(popup.saveButton.textChanges).toContain('Save')
   })
 
   it('retrieves and displays saved note', async () => {
-    Story.id.mockResolvedValue('123')
+    mockedStory.id.mockResolvedValue('123')
+    // @ts-expect-error - Migrating from JS
     global.chrome.storage.sync.get.mockResolvedValue({'notes_123': 'Saved note'})
     const popup = new NotesPopup()
     await popup.set()
+    // @ts-expect-error - Migrating from JS
     expect(document.getElementById('storyNotes').value).toBe('Saved note')
   })
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {chrome} from 'jest-chrome'
 
 


### PR DESCRIPTION
This commit adds the ability for users to customise the names of their workflow states in the "Shortcut Assistant" application's settings. This functionality was achieved by including new input fields in the settings UI and integrating corresponding data handlers in the back-end scripts. In addition, to facilitate this change, various utilities and test files were modified and updated, correspondingly.