### PR TITLE
Update popup with status page

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -11,3 +11,4 @@
 - [ ] View cycle time on a completed story
   - [ ] On page load
   - [ ] On SPA navigation
+- [ ] Add notes to a story

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,6 +2,7 @@
 
 # Tested
 - [ ] View and Interact with Todoist buttons
+  - [ ] View Story page with Todoist disabled
 - [ ] Use both analyze and break down AI features
   - [ ] With proxy
   - [ ] Without proxy

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -70,12 +70,12 @@
         <div class="indicator">
             <a id="changelog" class="text-gray-400 hover:text-white cursor-pointer" href="updated.html" target="_top">What's New</a>
             <span id="whatsNewBadge" class="indicator-item badge badge-secondary"></span>
-        </div>
-
+        </div><br>
     </div>
     <div class="flex justify-center items-center gap-2">
-        <a href="https://github.com/JensAstrup/shortcut-assistant" target="_blank" class="btn btn-outline btn-xs mb-2">GitHub Homepage</a>
-        <a href="https://github.com/JensAstrup/shortcut-assistant/blob/main/docs/privacy.md" target="_blank" class="btn btn-outline btn-xs mb-2">Privacy Policy</a>
+        <a href="https://github.com/JensAstrup/shortcut-assistant" target="_blank" class="btn btn-outline btn-xs mb-2">GitHub</a>
+        <a href="https://status.jensastrup.io" target="_blank" class="btn btn-outline btn-xs mb-2">Status Page</a>
+        <a href="https://shortcut-assistant.jensastrup.io/privacy" target="_blank" class="btn btn-outline btn-xs mb-2">Privacy Policy</a>
     </div>
 </div>
 


### PR DESCRIPTION
## What's Changed
Added a link to the new status page on the settings tab of the popup

# Tested
- [x] View and Interact with Todoist buttons
- [x] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [x] On SPA navigation
- [ ] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
