### PR TITLE
SHA-177: Update proxy JSON fields

### DIFF
--- a/src/js/ai/fetch-completion.ts
+++ b/src/js/ai/fetch-completion.ts
@@ -1,43 +1,40 @@
 import OpenAI from 'openai'
-import {Chat} from 'openai/resources'
+import { Chat } from 'openai/resources'
 
-import {AiPromptType} from '@sx/analyze/types/ai-prompt-type'
-import {AiProcessMessage, AiProcessMessageType} from '@sx/analyze/types/AiProcessMessage'
+import { AiPromptType } from '@sx/analyze/types/ai-prompt-type'
+import { AiProcessMessage, AiProcessMessageType } from '@sx/analyze/types/AiProcessMessage'
 
-import getOpenAiToken from './get-openai-token'
 import PROMPT from './prompt'
 
 import ChatCompletionMessageParam = Chat.ChatCompletionMessageParam
 
 
-const BREAKUP_PROMPT = 'You are a Senior Engineering Manager who is assisting team members with taking' +
-  ' a large user story and breaking it up into smaller  more approachable (from an engineering work' +
-  ' perspective) stories and subtasks. ' +
-  '' +
-  'Only respond with new stories, structured/formatted like the one the user gave you.' +
-  ' Do not be verbose. Do not include story titles. Separate all stories you create with `---`.'
+const BREAKUP_PROMPT = 'You are a Senior Engineering Manager who is assisting team members with taking'
+  + ' a large user story and breaking it up into smaller  more approachable (from an engineering work'
+  + ' perspective) stories and subtasks. '
+  + ''
+  + 'Only respond with new stories, structured/formatted like the one the user gave you.'
+  + ' Do not be verbose. Do not include story titles. Separate all stories you create with `---`.'
 
-const promptTypes:  Record<AiPromptType, string> = {
+const promptTypes: Record<AiPromptType, string> = {
   breakup: BREAKUP_PROMPT,
   analyze: PROMPT
 }
 
-export async function fetchCompletion(description: string, type: AiPromptType, tabId: number) {
-  const openAIToken = await getOpenAiToken()
-  const openai = new OpenAI({apiKey: openAIToken})
-  const messages: ChatCompletionMessageParam[] = [{role: 'system', content: promptTypes[type]},
-    {role: 'user', content: description}]
+export async function fetchCompletion(description: string, type: AiPromptType, tabId: number, token: string): Promise<void> {
+  const openai = new OpenAI({ apiKey: token })
+  const messages: ChatCompletionMessageParam[] = [{ role: 'system', content: promptTypes[type] },
+    { role: 'user', content: description }]
   const stream = await openai.chat.completions.create({
     messages: messages,
     model: 'gpt-4-turbo-preview',
     stream: true
   })
-  // eslint-disable-next-line no-loops/no-loops
   for await (const chunk of stream) {
     const content = chunk.choices[0]?.delta?.content || ''
-    const data = {content, type}
+    const data = { content, type }
     // TODO: Not awaiting here could be the cause of the issue where message content is misplaced
-    chrome.tabs.sendMessage(tabId, {type: AiProcessMessageType.updated, data} as AiProcessMessage)
+    chrome.tabs.sendMessage(tabId, { type: AiProcessMessageType.updated, data } as AiProcessMessage)
   }
-  chrome.runtime.sendMessage({type: AiProcessMessageType.completed, message: type} as AiProcessMessage)
+  chrome.runtime.sendMessage({ type: AiProcessMessageType.completed, message: type } as AiProcessMessage)
 }

--- a/src/js/ai/get-openai-token.ts
+++ b/src/js/ai/get-openai-token.ts
@@ -1,6 +1,6 @@
-async function getOpenAiToken() {
+async function getOpenAiToken(): Promise<string | null> {
   try {
-    const result = await chrome.storage.local.get('openAIToken')
+    const result: { [key: string]: string | undefined } = await chrome.storage.local.get('openAIToken')
     const value = result.openAIToken
     if (value !== undefined) {
       return value

--- a/src/js/service-worker/handlers.ts
+++ b/src/js/service-worker/handlers.ts
@@ -1,8 +1,7 @@
 import callOpenAi from '@sx/ai/call-openai'
-import getOpenAiToken from '@sx/ai/get-openai-token'
-import {AiPromptType} from '@sx/analyze/types/ai-prompt-type'
-import {getActiveTab} from '@sx/utils/get-active-tab'
-import {Story} from '@sx/utils/story'
+import { AiPromptType } from '@sx/analyze/types/ai-prompt-type'
+import { getActiveTab } from '@sx/utils/get-active-tab'
+import { Story } from '@sx/utils/story'
 
 
 async function handleOpenAICall(prompt: string, type: AiPromptType, tabId: number): Promise<void | {
@@ -13,37 +12,31 @@ async function handleOpenAICall(prompt: string, type: AiPromptType, tabId: numbe
   }
   catch (e: unknown) {
     console.error('Error calling OpenAI:', e)
-    chrome.tabs.sendMessage(tabId, {message: 'OpenAIResponseFailed'})
-    return {error: e as Error}
+    chrome.tabs.sendMessage(tabId, { message: 'OpenAIResponseFailed' })
+    return { error: e as Error }
   }
-}
-
-async function handleGetOpenAiToken(): Promise<{ token: string }> {
-  const token = await getOpenAiToken()
-  return {token}
 }
 
 async function handleGetSavedNotes(): Promise<{ data: string | null }> {
   const value = await Story.notes()
-  return {data: value}
+  return { data: value }
 }
 
-export async function handleCommands(command: string) {
+export async function handleCommands(command: string): Promise<void> {
   const activeTab = await getActiveTab()
   if (!activeTab || !activeTab.id) {
     return
   }
   if (command === 'change-state') {
-    await chrome.tabs.sendMessage(activeTab.id, {message: 'change-state'})
+    await chrome.tabs.sendMessage(activeTab.id, { message: 'change-state' })
   }
   else if (command === 'change-iteration') {
-    await chrome.tabs.sendMessage(activeTab.id, {message: 'change-iteration'})
+    await chrome.tabs.sendMessage(activeTab.id, { message: 'change-iteration' })
   }
   else if (command === 'copy-git-branch') {
-    await chrome.tabs.sendMessage(activeTab.id, {message: 'copy-git-branch'})
+    await chrome.tabs.sendMessage(activeTab.id, { message: 'copy-git-branch' })
   }
 }
 
-export {handleGetSavedNotes}
-export {handleGetOpenAiToken}
-export {handleOpenAICall}
+export { handleGetSavedNotes }
+export { handleOpenAICall }

--- a/src/js/service-worker/listeners.ts
+++ b/src/js/service-worker/listeners.ts
@@ -1,7 +1,6 @@
 import { sendEvent } from '@sx/analytics/event'
 import { AiPromptType } from '@sx/analyze/types/ai-prompt-type'
 import {
-  handleGetOpenAiToken,
   handleGetSavedNotes,
   handleOpenAICall
 } from '@sx/service-worker/handlers'
@@ -22,11 +21,6 @@ function registerAiListeners(): void {
       }
       handleOpenAICall(request.data.prompt, request.data.type, sender.tab.id).then(sendResponse)
       return true // Keep the message channel open for the async response
-    }
-
-    if (request.message === 'getOpenAiToken') {
-      handleGetOpenAiToken().then(sendResponse)
-      return true
     }
   })
 }

--- a/tests/ai/call-openai.test.ts
+++ b/tests/ai/call-openai.test.ts
@@ -1,9 +1,9 @@
 import callOpenAI from '@sx/ai/call-openai'
-import {fetchCompletion} from '@sx/ai/fetch-completion'
+import { fetchCompletion } from '@sx/ai/fetch-completion'
 import getCompletionFromProxy from '@sx/ai/get-completion-from-proxy'
 import getOpenAiToken from '@sx/ai/get-openai-token'
-import {sendEvent} from '@sx/analytics/event'
-import {OpenAIError} from '@sx/utils/errors'
+import { sendEvent } from '@sx/analytics/event'
+import { OpenAIError } from '@sx/utils/errors'
 import scope from '@sx/utils/sentry'
 
 
@@ -63,8 +63,8 @@ describe('callOpenAI', () => {
 
     await callOpenAI(description, 'analyze', tabId)
 
-    expect(mockFetchCompletion).toHaveBeenCalledWith(description, 'analyze', tabId)
-    expect(sendEvent).toHaveBeenCalledWith('ai', {token_provided: true, type: 'analyze'})
+    expect(mockFetchCompletion).toHaveBeenCalledWith(description, 'analyze', tabId, token)
+    expect(sendEvent).toHaveBeenCalledWith('ai', { token_provided: true, type: 'analyze' })
   })
 
   it('should throw OpenAIError when fetchCompletion fails', async () => {

--- a/tests/ai/fetch-completion.test.ts
+++ b/tests/ai/fetch-completion.test.ts
@@ -1,14 +1,11 @@
 import OpenAI from 'openai'
 
-import {fetchCompletion} from '@sx/ai/fetch-completion'
-import getOpenAiToken from '@sx/ai/get-openai-token'
-import {AiProcessMessageType} from '@sx/analyze/types/AiProcessMessage'
+import { fetchCompletion } from '@sx/ai/fetch-completion'
+import { AiProcessMessageType } from '@sx/analyze/types/AiProcessMessage'
 
 // Mock the required modules
 jest.mock('openai')
-jest.mock('@sx/ai/get-openai-token')
 
-const mockGetOpenAiToken = getOpenAiToken as jest.MockedFunction<typeof getOpenAiToken>
 const mockOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>
 
 describe('fetchCompletion', () => {
@@ -18,11 +15,10 @@ describe('fetchCompletion', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetOpenAiToken.mockResolvedValue(fakeToken)
 
     const mockCreate = jest.fn().mockImplementation(() => {
-      const mockStream = (async function* () {
-        yield {choices: [{delta: {content: 'response from OpenAI'}}]}
+      const mockStream = (function* (): Generator<{ choices: [{ delta: { content: string } }] }> {
+        yield { choices: [{ delta: { content: 'response from OpenAI' } }] }
       })()
       return mockStream
     })
@@ -38,10 +34,10 @@ describe('fetchCompletion', () => {
   })
 
   it('successfully fetches and handles data from OpenAI', async () => {
-    await fetchCompletion(description, 'analyze', tabId)
+    await fetchCompletion(description, 'analyze', tabId, 'fake_token')
 
     // Check OpenAI was initialized correctly
-    expect(mockOpenAI).toHaveBeenCalledWith({apiKey: fakeToken})
+    expect(mockOpenAI).toHaveBeenCalledWith({ apiKey: fakeToken })
 
     // Verify messages sent to the Chrome tab
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(tabId, {
@@ -53,8 +49,6 @@ describe('fetchCompletion', () => {
     })
 
     // Check final message to runtime
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({type: AiProcessMessageType.completed, message: 'analyze'})
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: AiProcessMessageType.completed, message: 'analyze' })
   })
-
-  // Additional tests for error scenarios...
 })

--- a/tests/service-worker/service-worker.test.ts
+++ b/tests/service-worker/service-worker.test.ts
@@ -1,8 +1,7 @@
-import {chrome} from 'jest-chrome'
+import { chrome } from 'jest-chrome'
 
-import {sendEvent} from '@sx/analytics/event'
+import { sendEvent } from '@sx/analytics/event'
 import {
-  handleGetOpenAiToken,
   handleGetSavedNotes,
   handleOpenAICall
 } from '@sx/service-worker/handlers'
@@ -13,15 +12,15 @@ import ManifestV3 = chrome.runtime.ManifestV3
 
 jest.mock('@sx/utils/sentry')
 jest.mock('@sx/service-worker/handlers', () => ({
-  handleOpenAICall: jest.fn().mockResolvedValue({data: 'mock'}),
-  handleGetOpenAiToken: jest.fn().mockResolvedValue({token: 'mock'}),
-  handleGetSavedNotes: jest.fn().mockResolvedValue({data: 'mock'}),
+  handleOpenAICall: jest.fn().mockResolvedValue({ data: 'mock' }),
+  handleGetSavedNotes: jest.fn().mockResolvedValue({ data: 'mock' }),
 }))
 
 jest.mock('../../src/js/analytics/event', () => ({
   sendEvent: jest.fn().mockResolvedValue({}),
 }))
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 Object.assign(global, require('jest-chrome'))
 
 
@@ -47,8 +46,8 @@ describe('chrome.runtime.onMessage listener', () => {
 
     chrome.runtime.onMessage.callListeners({
       action: 'callOpenAI',
-      data: {prompt: mockPrompt}
-    }, {tab: {id: mockTabId, index: 0, pinned: false, windowId: 1, active: true} as Tab}, sendResponse)
+      data: { prompt: mockPrompt }
+    }, { tab: { id: mockTabId, index: 0, pinned: false, windowId: 1, active: true } as Tab }, sendResponse)
 
     expect(handleOpenAICall).toHaveBeenCalledWith(mockPrompt, undefined, mockTabId)
     await new Promise(process.nextTick) // Wait for all promises to resolve
@@ -59,23 +58,11 @@ describe('chrome.runtime.onMessage listener', () => {
     const sendResponse = jest.fn()
     chrome.runtime.onMessage.callListeners({
       action: 'callOpenAI',
-      data: {prompt: 'prompt'}
+      data: { prompt: 'prompt' }
     }, {}, sendResponse)
 
     expect(sendResponse).not.toHaveBeenCalled()
     expect(handleOpenAICall).not.toHaveBeenCalled()
-  })
-
-  it('calls handleGetOpenAiToken when message is "getOpenAiToken"', async () => {
-    const sendResponse = jest.fn()
-
-    chrome.runtime.onMessage.callListeners({
-      message: 'getOpenAiToken'
-    }, {}, sendResponse)
-
-    await new Promise(process.nextTick)
-    expect(handleGetOpenAiToken).toHaveBeenCalled()
-    expect(sendResponse).toHaveBeenCalled()
   })
 
   it('calls handleGetSavedNotes when action is "getSavedNotes"', async () => {
@@ -93,13 +80,13 @@ describe('chrome.runtime.onMessage listener', () => {
   it('calls sendEvent when action is "sendEvent" and data is valid', async () => {
     const sendResponse = jest.fn()
     const mockEventName = 'userLogin'
-    const mockParams = {user: 'testUser'}
+    const mockParams = { user: 'testUser' }
 
     require('@sx/service-worker/service-worker')
 
     chrome.runtime.onMessage.callListeners({
       action: 'sendEvent',
-      data: {eventName: mockEventName, params: mockParams}
+      data: { eventName: mockEventName, params: mockParams }
     }, {}, sendResponse)
 
     // await new Promise(process.nextTick)


### PR DESCRIPTION
## What's Changed
The JSON body expected by the proxy server is changing from `description` and `prompt_type` to `content` and `promptType`. This reflects those changes. Following a base linter config upgrade in an earlier PR, this also has a host of assorted lint changes which are required for a passing build.

# Tested
- [ ] View and Interact with Todoist buttons
  - [ ] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [ ] With proxy
  - [ ] Without proxy
- [ ] View development time for in progress stories
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] Add notes to a story
