### PR TITLE
SHA-179: Fix timing issue with development time rendering

### DIFF
--- a/src/js/development-time/development-time.ts
+++ b/src/js/development-time/development-time.ts
@@ -1,4 +1,4 @@
-import {Story} from '@sx/utils/story'
+import { Story } from '@sx/utils/story'
 import Workspace from '@sx/workspace/workspace'
 
 
@@ -17,14 +17,14 @@ export class DevelopmentTime {
     stateSpan.appendChild(timeSpan)
   }
 
-  static remove() {
+  static remove(): void {
     const timeSpan = document.querySelector('[data-assistant="true"]')
     if (timeSpan) {
       timeSpan.remove()
     }
   }
 
-  static async set() {
+  static async set(): Promise<void> {
     await Story.isReady()
     this.remove()
     const states = await Workspace.states()

--- a/src/js/utils/story.ts
+++ b/src/js/utils/story.ts
@@ -24,13 +24,11 @@ export class Story {
     const WAIT_FOR_PAGE_TO_LOAD_TIMEOUT: number = 1_000
     const MAX_ATTEMPTS: number = 10
     const storyTitle: Element | null = document.querySelector('.story-name')
-
-    if (storyTitle !== null || loop >= MAX_ATTEMPTS) {
-      const waitTime = 200
-      await sleep(waitTime)
+    const storyDescription: Element | null = document.querySelector('#story-description-v2')
+    const storyDescriptionText: string | null | undefined = storyDescription?.textContent
+    if ((storyTitle !== null && storyDescriptionText) || loop >= MAX_ATTEMPTS) {
       return storyTitle !== null
     }
-
     await sleep(loop * WAIT_FOR_PAGE_TO_LOAD_TIMEOUT)
     return this.isReady(loop + 1)
   }

--- a/tests/utils/story.test.ts
+++ b/tests/utils/story.test.ts
@@ -1,20 +1,24 @@
+// import { chrome } from 'jest-chrome'
+
 import {
   findFirstMatchingElementForState
 } from '@sx/development-time/find-first-matching-element-for-state'
 import * as urlModule from '@sx/utils/get-active-tab-url'
-import {ShortcutWorkflowStates} from '@sx/utils/get-states'
 import scope from '@sx/utils/sentry'
-import {Story} from '@sx/utils/story'
+import { Story } from '@sx/utils/story'
 import Workspace from '@sx/workspace/workspace'
+
+import Mock = jest.Mock
 
 
 const mockNow = {
   format: jest.fn().mockReturnValueOnce('Feb 1 2022, 2:00 AM'),
-  subtract: jest.fn().mockReturnValueOnce({format: jest.fn().mockReturnValueOnce('Jan 31 2022, 2:00 AM')}),
+  subtract: jest.fn().mockReturnValueOnce({ format: jest.fn().mockReturnValueOnce('Jan 31 2022, 2:00 AM') }),
   isAfter: jest.fn().mockReturnValueOnce(true),
-  add: jest.fn().mockReturnValueOnce({format: jest.fn().mockReturnValueOnce('Feb 2 2022, 2:00 AM')})
+  add: jest.fn().mockReturnValueOnce({ format: jest.fn().mockReturnValueOnce('Feb 2 2022, 2:00 AM') })
 }
 jest.mock('dayjs', () => {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   return () => (mockNow)
 })
 jest.mock('@sx/utils/sentry')
@@ -25,18 +29,19 @@ jest.mock('@sx/utils/hours-between-excluding-weekends', () => ({
 jest.mock('@sx/development-time/find-first-matching-element-for-state', () => ({
   findFirstMatchingElementForState: jest.fn()
 }))
+const mockFindFirstMatchingElementForState = findFirstMatchingElementForState as Mock
 jest.mock('@sx/utils/sleep', () => jest.fn().mockResolvedValue(undefined))
 jest.mock('@sx/utils/get-active-tab-url', () => ({
   getActiveTabUrl: jest.fn()
 }))
-jest.spyOn(Workspace, 'states').mockImplementation(async (): Promise<ShortcutWorkflowStates | null> => {
-  return {
-    'Backlog': ['To Do'],
-    'Unstarted': ['Waiting'],
-    'Started': ['In Development'],
-    'Done': []
-  }
+jest.spyOn(Workspace, 'states').mockResolvedValue({
+  Backlog: ['To Do'],
+  Unstarted: ['Waiting'],
+  Started: ['In Development'],
+  Done: []
 })
+
+
 
 describe('Story.isReady', () => {
   const originalDocumentQuerySelector = document.querySelector
@@ -45,7 +50,15 @@ describe('Story.isReady', () => {
     jest.mock('@sx/utils/sleep', () => jest.fn().mockResolvedValue(undefined))
 
     document.querySelector = jest.fn((selector) => {
-      return (selector === '.story-name') ? {} : null
+      if (selector === '.story-name') {
+        return {}
+      }
+      else if (selector === '#story-description-v2') {
+        return { textContent: 'Sample Description' }
+      }
+      else {
+        return null
+      }
     })
   })
 
@@ -55,7 +68,7 @@ describe('Story.isReady', () => {
     document.querySelector = originalDocumentQuerySelector
   })
 
-  it('should resolve to true when a story title can be found on the page', async () => {
+  it('should resolve to true when a story title and description can be found on the page', async () => {
     await expect(Story.isReady()).resolves.toBe(true)
   })
 
@@ -66,7 +79,7 @@ describe('Story.isReady', () => {
     // eslint-disable-next-line no-magic-numbers
     expect(document.querySelector).toHaveBeenNthCalledWith(9, '.story-name')
     // 10 calls to document.querySelector for story title and historical changes, each, plus the initial call
-    const EXPECTED_CALLS = 11
+    const EXPECTED_CALLS = 22
     expect(document.querySelector).toHaveBeenCalledTimes(EXPECTED_CALLS)
   })
 })
@@ -106,43 +119,36 @@ describe('Story.description', () => {
     expect(Story.description).toBeNull()
   })
 
-  it('should return null when description is not set', () => {
+  it('should return null when description does not exist', () => {
     document.body.innerHTML = '<div></div>'
     expect(Story.description).toBeNull()
   })
 })
 
 describe('getEditDescriptionButtonContainer', () => {
-  // @ts-expect-error Remnants from before typescript implementation
-  let originalQuerySelector
+  let querySelector: jest.SpyInstance
 
   beforeEach(() => {
-    originalQuerySelector = document.querySelector
-
-    document.querySelector = jest.fn()
+    querySelector = jest.spyOn(document, 'querySelector')
   })
 
   afterEach(() => {
-    // @ts-expect-error Remnants from before typescript implementation
-    document.querySelector = originalQuerySelector
     jest.clearAllTimers()
   })
 
   it('should return the container immediately if the button is found', async () => {
     const mockContainer = document.createElement('div')
-    // @ts-expect-error Remnants from before typescript implementation
-    document.querySelector.mockReturnValue(mockContainer)
+    querySelector.mockReturnValue(mockContainer)
 
     const container = await Story.getEditDescriptionButtonContainer()
 
     expect(container).toBe(mockContainer)
-    expect(document.querySelector).toHaveBeenCalledTimes(1)
+    expect(querySelector).toHaveBeenCalledTimes(1)
   })
 
 
   it('should return null if the button is not found within the maximum number of attempts', async () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    document.querySelector.mockReturnValue(null)
+    querySelector.mockReturnValue(null)
 
     const promise = Story.getEditDescriptionButtonContainer()
 
@@ -150,7 +156,7 @@ describe('getEditDescriptionButtonContainer', () => {
 
     expect(container).toBeNull()
     const expectedAttempts = 11
-    expect(document.querySelector).toHaveBeenCalledTimes(expectedAttempts)
+    expect(querySelector).toHaveBeenCalledTimes(expectedAttempts)
   })
 })
 
@@ -183,7 +189,7 @@ describe('Story.getTimeInState', () => {
     expect(result).toBe(ONE_DAY)
   })
 
-  it('returns the difference between now and the date in state', () => {
+  it('returns null if the state is invalid', () => {
     jest.spyOn(Story, 'getDateInState').mockReturnValue(null)
     const result = Story.getTimeInState('13')
     expect(mockNow.format).toHaveBeenCalledWith('MMM D YYYY, h:mm A')
@@ -201,30 +207,26 @@ describe('Story.getDateInState', () => {
   })
 
   it('returns null when no elements match the state', () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    findFirstMatchingElementForState.mockReturnValueOnce(null)
+    mockFindFirstMatchingElementForState.mockReturnValueOnce(null)
 
     const result = Story.getDateInState('NonExistentState')
     expect(result).toBeNull()
-
   })
 
   it('returns the date when state matches and date element exists', () => {
     const latestUpdateElement = {
       parentElement: {
-        querySelector: jest.fn().mockReturnValueOnce({innerHTML: '2022-03-01'})
+        querySelector: jest.fn().mockReturnValueOnce({ innerHTML: '2022-03-01' })
       }
     }
-    // @ts-expect-error Remnants from before typescript implementation
-    findFirstMatchingElementForState.mockReturnValueOnce({element: latestUpdateElement})
+    mockFindFirstMatchingElementForState.mockReturnValueOnce({ element: latestUpdateElement })
 
     const result = Story.getDateInState('ExpectedState2')
     expect(result).toBe('2022-03-01')
   })
 
   it('returns null when state div and date element do not exist', () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    findFirstMatchingElementForState.mockReturnValueOnce({element: {parentElement: {querySelector: jest.fn().mockReturnValueOnce(null)}}})
+    mockFindFirstMatchingElementForState.mockReturnValueOnce({ element: { parentElement: { querySelector: jest.fn().mockReturnValueOnce(null) } } })
     const result = Story.getDateInState('ExpectedState')
     expect(result).toBeNull()
   })
@@ -245,23 +247,22 @@ describe('Story.state', () => {
 
 describe('isCompleted', () => {
   beforeEach(() => {
-    jest.spyOn(Workspace, 'states').mockImplementation(async (): Promise<ShortcutWorkflowStates | null> => {
-      return {
-        'Backlog': ['To Do'],
-        'Unstarted': ['Waiting'],
-        'Started': ['In Development'],
-        'Done': ['Done']
-      }
+    // eslint-disable-next-line @typescript-eslint/require-await
+    jest.spyOn(Workspace, 'states').mockResolvedValue({
+      Backlog: ['To Do'],
+      Unstarted: ['Waiting'],
+      Started: ['In Development'],
+      Done: ['Done']
     })
   })
   it('should return true if the story is in a done state', async () => {
-    jest.spyOn(Story, 'state', 'get').mockReturnValue({textContent: 'Done'} as unknown as HTMLElement)
+    jest.spyOn(Story, 'state', 'get').mockReturnValue({ textContent: 'Done' } as unknown as HTMLElement)
     const result = await Story.isCompleted()
     expect(result).toBe(true)
   })
 
   it('should return false if the story is not in a done state', async () => {
-    jest.spyOn(Story, 'state', 'get').mockReturnValue({textContent: 'In Development'} as unknown as HTMLElement)
+    jest.spyOn(Story, 'state', 'get').mockReturnValue({ textContent: 'In Development' } as unknown as HTMLElement)
     const result = await Story.isCompleted()
     expect(result).toBe(false)
   })
@@ -272,13 +273,11 @@ describe('isInState function', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     document.body.innerHTML = '<div id="story-dialog-state-dropdown"><span class="value">In Development</span></div>'
-    jest.spyOn(Workspace, 'states').mockImplementation(async (): Promise<ShortcutWorkflowStates | null> => {
-      return {
-        'Backlog': ['To Do'],
-        'Unstarted': ['Waiting'],
-        'Started': ['In Development'],
-        'Done': []
-      }
+    jest.spyOn(Workspace, 'states').mockResolvedValue({
+      Backlog: ['To Do'],
+      Unstarted: ['Waiting'],
+      Started: ['In Development'],
+      Done: []
     })
   })
 
@@ -287,7 +286,7 @@ describe('isInState function', () => {
     document.getElementById = jest.fn(() => {
       return {
         querySelector: jest.fn(() => {
-          return {textContent: state}
+          return { textContent: state }
         })
       } as unknown as HTMLElement
     })
@@ -298,7 +297,7 @@ describe('isInState function', () => {
     document.getElementById = jest.fn(() => {
       return {
         querySelector: jest.fn(() => {
-          return {textContent: 'TestState, In Development'}
+          return { textContent: 'TestState, In Development' }
         })
       } as unknown as HTMLElement
     })
@@ -342,23 +341,21 @@ describe('Story.notes', () => {
     jest.restoreAllMocks()
   })
 
-  it('should return story notes when set', () => {
+  it('should return story notes when set', async () => {
     jest.spyOn(Story, 'id').mockResolvedValue('123')
-    // @ts-expect-error Remnants from before typescript implementation
-    chrome.storage.sync.get.mockResolvedValue({notes_123: 'Test note'})
-    expect(Story.notes()).resolves.toBe('Test note')
+    jest.spyOn(chrome.storage.sync, 'get').mockResolvedValue({ notes_123: 'Test note' } as never)
+    await expect(Story.notes()).resolves.toBe('Test note')
   })
 
-  it('should return null when notes are not set', () => {
+  it('should return null when notes are not set', async () => {
     jest.spyOn(Story, 'id').mockResolvedValue('123')
-    // @ts-expect-error Remnants from before typescript implementation
-    chrome.storage.sync.get.mockResolvedValue({})
-    expect(Story.notes()).resolves.toBeNull()
+    jest.spyOn(chrome.storage.sync, 'get').mockResolvedValue({ notes_123: undefined } as never)
+    await expect(Story.notes()).resolves.toBeNull()
   })
 
-  it('should return null when story ID is not set', () => {
+  it('should return null when story ID is not set', async () => {
     jest.spyOn(Story, 'id').mockResolvedValue(null)
-    expect(Story.notes()).resolves.toBeNull()
+    await expect(Story.notes()).resolves.toBeNull()
   })
 })
 

--- a/tests/utils/story.test.ts
+++ b/tests/utils/story.test.ts
@@ -361,26 +361,22 @@ describe('Story.notes', () => {
 
 describe('Story id', () => {
   it('returns the correct story ID from a valid URL', async () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    urlModule.getActiveTabUrl.mockResolvedValue('https://app.shortcut.com/story/12345')
+    jest.spyOn(urlModule, 'getActiveTabUrl').mockResolvedValue('https://app.shortcut.com/story/12345')
     await expect(Story.id()).resolves.toBe('12345')
   })
 
   it('returns null if the URL does not contain a story ID', async () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    urlModule.getActiveTabUrl.mockResolvedValue('https://app.shortcut.com/profile')
+    jest.spyOn(urlModule, 'getActiveTabUrl').mockResolvedValue('https://app.shortcut.com/profile')
     await expect(Story.id()).resolves.toBeNull()
   })
 
   it('handles URLs with additional path segments correctly', async () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    urlModule.getActiveTabUrl.mockResolvedValue('https://app.shortcut.com/story/12345/details')
+    jest.spyOn(urlModule, 'getActiveTabUrl').mockResolvedValue('https://app.shortcut.com/story/12345/details')
     await expect(Story.id()).resolves.toBe('12345')
   })
 
   it('returns null if getActiveTabUrl rejects', async () => {
-    // @ts-expect-error Remnants from before typescript implementation
-    urlModule.getActiveTabUrl.mockRejectedValue(new Error('Error fetching URL'))
+    jest.spyOn(urlModule, 'getActiveTabUrl').mockRejectedValue(new Error('Error fetching URL'))
     await expect(Story.id()).rejects.toThrow('Error fetching URL')
   })
 })


### PR DESCRIPTION
## What's Changed
Fixes and issue where the development time stats would only show on SPA navigation changes and not initial page loads. This actually manages to not only resolve the issue, but noticeably improve rendering times. 

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [x] On SPA navigation
- [x] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
- [x] Add notes to a story
