### PR TITLE
SHA-180: Has notes should follow todoist

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
     "node-html-parser": "^6.1.13",
     "openai": "4.38.5",
     "uuid": "^9.0.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/src/js/content-scripts.ts
+++ b/src/js/content-scripts.ts
@@ -35,7 +35,7 @@ export async function activate(): Promise<void> {
     if (enableTodoistOptions) {
       // Wait on response because AiFunctions.addAnalyzeButton() will also set a button
       // and async could affect the order
-      Todoist.setTaskButtons()
+      await Todoist.setTaskButtons()
     }
   }
   catch (e) {

--- a/src/js/content-scripts.ts
+++ b/src/js/content-scripts.ts
@@ -52,7 +52,6 @@ export async function handleMessage(request: { message: string, url: string }): 
   if (request.message === 'update') {
     DevelopmentTime.set().catch(logError)
     CycleTime.set().catch(logError)
-    new NotesButton()
     const functions = new AiFunctions()
     await functions.addButtons()
     const enableTodoistOptions = await getSyncedSetting('enableTodoistOptions', false)
@@ -61,6 +60,7 @@ export async function handleMessage(request: { message: string, url: string }): 
       // and async could affect the order
       await Todoist.setTaskButtons()
     }
+    new NotesButton()
   }
   if (request.message === 'change-state') {
     await changeState()

--- a/src/js/utils/story.ts
+++ b/src/js/utils/story.ts
@@ -84,8 +84,8 @@ export class Story {
       container?.appendChild(newButton)
     }
     // Prevent duplicate buttons
-    const TWO_SECONDS = 2000
-    sleep(TWO_SECONDS).then(() => {
+    const WAIT = 200
+    sleep(WAIT).then(() => {
       const existingButtons = document.querySelectorAll(`button[data-${identifier}="true"]`)
       if (existingButtons.length > 1) {
         existingButtons[0].remove()

--- a/tests/content-scripts.test.ts
+++ b/tests/content-scripts.test.ts
@@ -1,15 +1,15 @@
-import {AiFunctions} from '@sx/analyze/ai-functions'
-import {analyzeStoryDescription} from '@sx/analyze/analyze-story-description'
-import {activate, handleMessage} from '@sx/content-scripts'
-import {CycleTime} from '@sx/cycle-time/cycle-time'
-import {DevelopmentTime} from '@sx/development-time/development-time'
+import { AiFunctions } from '@sx/analyze/ai-functions'
+import { analyzeStoryDescription } from '@sx/analyze/analyze-story-description'
+import { activate, handleMessage } from '@sx/content-scripts'
+import { CycleTime } from '@sx/cycle-time/cycle-time'
+import { DevelopmentTime } from '@sx/development-time/development-time'
 import changeIteration from '@sx/keyboard-shortcuts/change-iteration'
 import changeState from '@sx/keyboard-shortcuts/change-state'
 import copyGitBranch from '@sx/keyboard-shortcuts/copy-git-branch'
-import {NotesButton} from '@sx/notes/notes-button'
-import {Todoist} from '@sx/todoist/todoist'
-import {getSyncedSetting} from '@sx/utils/get-synced-setting'
-import {Story} from '@sx/utils/story'
+import { NotesButton } from '@sx/notes/notes-button'
+import { Todoist } from '@sx/todoist/todoist'
+import { getSyncedSetting } from '@sx/utils/get-synced-setting'
+import { Story } from '@sx/utils/story'
 
 
 jest.mock('@sx/development-time/development-time', () => ({
@@ -110,7 +110,7 @@ describe('handleMessage function', () => {
 
 
   it('calls analyzeStoryDescription for analyzeStoryDescription message', async () => {
-    const request = {message: 'analyzeStoryDescription', url: ''}
+    const request = { message: 'analyzeStoryDescription', url: '' }
     await handleMessage(request)
     expect(analyzeStoryDescription).toHaveBeenCalledWith('https://example.com/story')
   })
@@ -118,7 +118,7 @@ describe('handleMessage function', () => {
   it('initializes on update message', async () => {
     // const spy = jest.spyOn(AiFunctions.prototype, 'addButtons')
     mockedGetSyncedSetting.mockResolvedValue(true)
-    const request = {message: 'update', url: 'https://example.com/story'}
+    const request = { message: 'update', url: 'https://example.com/story' }
     await handleMessage(request)
     expect(DevelopmentTime.set).toHaveBeenCalled()
     expect(CycleTime.set).toHaveBeenCalled()
@@ -127,19 +127,19 @@ describe('handleMessage function', () => {
   })
 
   it('calls changeState for change-state message', async () => {
-    const request = {message: 'change-state', url: 'https://example.com/story'}
+    const request = { message: 'change-state', url: 'https://example.com/story' }
     await handleMessage(request)
     expect(changeState).toHaveBeenCalled()
   })
 
   it('calls changeIteration for change-iteration message', async () => {
-    const request = {message: 'change-iteration', url: 'https://example.com/story'}
+    const request = { message: 'change-iteration', url: 'https://example.com/story' }
     await handleMessage(request)
     expect(changeIteration).toHaveBeenCalled()
   })
 
   it('calls copyGitBranch for copy-git-branch message', async () => {
-    const request = {message: 'copy-git-branch', url: 'https://example.com/story'}
+    const request = { message: 'copy-git-branch', url: 'https://example.com/story' }
     await handleMessage(request)
     expect(copyGitBranch).toHaveBeenCalled()
   })

--- a/tests/utils/story.test.ts
+++ b/tests/utils/story.test.ts
@@ -1,10 +1,9 @@
-// import { chrome } from 'jest-chrome'
-
 import {
   findFirstMatchingElementForState
 } from '@sx/development-time/find-first-matching-element-for-state'
 import * as urlModule from '@sx/utils/get-active-tab-url'
 import scope from '@sx/utils/sentry'
+import sleep from '@sx/utils/sleep'
 import { Story } from '@sx/utils/story'
 import Workspace from '@sx/workspace/workspace'
 
@@ -389,15 +388,18 @@ describe('Story addButton', () => {
     const story = new Story()
     await story.addButton(button, 'test')
     expect(container.children).toContain(button)
+    // eslint-disable-next-line no-magic-numbers
+    expect(sleep).toHaveBeenCalledWith(200)
   })
 
   it('should not add a button if it already exists', async () => {
     const button = document.createElement('button')
     const container = document.createElement('div')
-    container.appendChild(button)
+    const querySelector = jest.spyOn(document, 'querySelector')
+    querySelector.mockReturnValue(button)
     jest.spyOn(Story, 'getEditDescriptionButtonContainer').mockResolvedValue(container)
     const story = new Story()
     await story.addButton(button, 'test')
-    expect(container.children.length).toBe(1)
+    expect(container.children.length).toBe(0)
   })
 })


### PR DESCRIPTION
## What's Changed
- `Has Notes` button now always follows Todoist buttons if enabled

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [ ] With proxy
  - [x] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [x] On SPA navigation
- [x] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
- [x] Add notes to a story
