### PR TITLE
SHA-182: Do not track development analytics

### DIFF
--- a/src/js/analytics/event.ts
+++ b/src/js/analytics/event.ts
@@ -1,11 +1,11 @@
-import {getOrCreateClientId} from './client-id'
+import { getOrCreateClientId } from './client-id'
 import {
   DEFAULT_ENGAGEMENT_TIME_IN_MSEC,
   GA_ENDPOINT,
   GOOGLE_ANALYTICS_API_SECRET,
   MEASUREMENT_ID
 } from './config'
-import {getOrCreateSessionId} from './session-id'
+import { getOrCreateSessionId } from './session-id'
 
 
 const version: string = chrome.runtime.getManifest().version
@@ -26,6 +26,7 @@ export async function sendEvent(eventName: string, params = {}): Promise<void> {
               session_id: await getOrCreateSessionId(),
               engagement_time_msec: DEFAULT_ENGAGEMENT_TIME_IN_MSEC,
               debug_mode: process.env.NODE_ENV === 'development',
+              internal: process.env.NODE_ENV === 'development',
               version,
               ...params
             }

--- a/tests/analytics/client-id.test.ts
+++ b/tests/analytics/client-id.test.ts
@@ -1,15 +1,13 @@
-/**
- * @jest-environment node
- */
-
-import {getOrCreateClientId} from '../../src/js/analytics/client-id'
+import { getOrCreateClientId } from '@sx/analytics/client-id'
 
 
-const get = jest.fn().mockResolvedValue({clientId: 'randomClientId'})
+const get = jest.fn().mockResolvedValue({ clientId: 'randomClientId' })
 const set = jest.fn()
 
 global.chrome = {
+  ...chrome,
   storage: {
+    ...chrome.storage,
     sync: {
       ...chrome.storage.sync,
       get: get,
@@ -25,7 +23,7 @@ describe('getOrCreateClientId function', () => {
 
   it('should return clientId when there is an existing Id in chrome storage', async () => {
     const expectedClientId = 'randomClientId'
-    get.mockResolvedValue({clientId: expectedClientId})
+    get.mockResolvedValue({ clientId: expectedClientId })
     const result = await getOrCreateClientId()
     expect(get).toHaveBeenCalledWith('clientId')
     expect(result).toBe(expectedClientId)
@@ -35,7 +33,7 @@ describe('getOrCreateClientId function', () => {
     get.mockResolvedValue({})
     const result = await getOrCreateClientId()
     expect(get).toHaveBeenCalledWith('clientId')
-    expect(set).toHaveBeenCalledWith({clientId: result})
+    expect(set).toHaveBeenCalledWith({ clientId: result })
     expect(result).toEqual(expect.any(String))
   })
 })

--- a/tests/analytics/event.test.ts
+++ b/tests/analytics/event.test.ts
@@ -1,24 +1,23 @@
-/**
- * @jest-environment node
- */
-
-import {getOrCreateClientId} from '../../src/js/analytics/client-id'
-import {sendEvent} from '../../src/js/analytics/event'
-import {getOrCreateSessionId} from '../../src/js/analytics/session-id'
+import { getOrCreateClientId } from '@sx/analytics/client-id'
 import {
+  DEFAULT_ENGAGEMENT_TIME_IN_MSEC,
   GA_ENDPOINT,
   GOOGLE_ANALYTICS_API_SECRET,
-  MEASUREMENT_ID,
-  DEFAULT_ENGAGEMENT_TIME_IN_MSEC
-} from '../../src/js/analytics/config'
+  MEASUREMENT_ID
+} from '@sx/analytics/config'
+import { sendEvent } from '@sx/analytics/event'
+import { getOrCreateSessionId } from '@sx/analytics/session-id'
 
 
 jest.mock('../../src/js/analytics/client-id', () => ({
   getOrCreateClientId: jest.fn()
 }))
+const mockGetOrCreateClientId = getOrCreateClientId as jest.Mock
+
 jest.mock('../../src/js/analytics/session-id', () => ({
   getOrCreateSessionId: jest.fn()
 }))
+const mockGetOrCreateSessionId = getOrCreateSessionId as jest.Mock
 
 describe('sendEvent', () => {
   const fakeClientId = 'fake-client-id'
@@ -28,13 +27,13 @@ describe('sendEvent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    getOrCreateClientId.mockResolvedValue(fakeClientId)
-    getOrCreateSessionId.mockResolvedValue(fakeSessionId)
+    mockGetOrCreateClientId.mockResolvedValue(fakeClientId)
+    mockGetOrCreateSessionId.mockResolvedValue(fakeSessionId)
   })
 
   it('calls the correct GA endpoint with the right parameters', async () => {
     const eventName = 'test_event'
-    const additionalParams = {key: 'value'}
+    const additionalParams = { key: 'value' }
 
     await sendEvent(eventName, additionalParams)
 
@@ -52,6 +51,7 @@ describe('sendEvent', () => {
                 session_id: fakeSessionId,
                 engagement_time_msec: DEFAULT_ENGAGEMENT_TIME_IN_MSEC,
                 debug_mode: false,
+                internal: false,
                 version,
                 ...additionalParams
               }


### PR DESCRIPTION
## What's Changed
Specify internal traffic for Google Analytics to prevent development testing from impacting analytics

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [x] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [ ] On SPA navigation
- [x] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
- [x] Add notes to a story
