### PR TITLE
SHA-187: Only run CI step on PR open/sync

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   prepare-release-assets:
+    if: github.event.action == 'opened' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.draft_release.outputs.upload_url }}


### PR DESCRIPTION
## What's Changed
- Only run CI step for preparing release assets on PR open/sync