### PR TITLE
SHA-184: Fix development time on SPA Navigation

### DIFF
--- a/src/js/utils/story.ts
+++ b/src/js/utils/story.ts
@@ -14,6 +14,18 @@ import sleep from './sleep'
 
 
 export class Story {
+  private static storyTitleLoaded(): boolean {
+    return document.querySelector('.story-name') !== null
+  }
+
+  private static storyDescriptionLoaded(): boolean {
+    return document.querySelector('#story-description-v2') !== null
+  }
+
+  private static historicalActivityLoaded(): boolean {
+    return document.querySelector('.historical-change-v2') !== null
+  }
+
   /**
    * Waits for the story title/name and historical activity (such as the story being created) to be
    * present on the page which indicates that the page is ready.
@@ -21,15 +33,19 @@ export class Story {
    * and false if the page is not ready after 10 seconds.
    **/
   static async isReady(loop: number = 0): Promise<boolean> {
-    const WAIT_FOR_PAGE_TO_LOAD_TIMEOUT: number = 1_000
-    const MAX_ATTEMPTS: number = 10
-    const storyTitle: Element | null = document.querySelector('.story-name')
-    const storyDescription: Element | null = document.querySelector('#story-description-v2')
-    const storyDescriptionText: string | null | undefined = storyDescription?.textContent
-    if ((storyTitle !== null && storyDescriptionText) || loop >= MAX_ATTEMPTS) {
-      return storyTitle !== null
+    const WAIT_FOR_PAGE_TO_LOAD_TIMEOUT: number = 300
+    const MAX_ATTEMPTS: number = 20
+    const storyTitleReady: boolean = this.storyTitleLoaded()
+    const storyDescriptionReady: boolean = this.storyDescriptionLoaded()
+    const historyActivityReady: boolean = this.historicalActivityLoaded()
+    if (storyTitleReady && storyDescriptionReady && historyActivityReady) {
+      return true
     }
-    await sleep(loop * WAIT_FOR_PAGE_TO_LOAD_TIMEOUT)
+    if (loop >= MAX_ATTEMPTS) {
+      throw new Error('Story page did not load in time')
+    }
+    const HALF_LOOP = 0.5
+    await sleep((loop * HALF_LOOP) * WAIT_FOR_PAGE_TO_LOAD_TIMEOUT)
     return this.isReady(loop + 1)
   }
 

--- a/tests/utils/story.test.ts
+++ b/tests/utils/story.test.ts
@@ -41,7 +41,6 @@ jest.spyOn(Workspace, 'states').mockResolvedValue({
 })
 
 
-
 describe('Story.isReady', () => {
   const originalDocumentQuerySelector = document.querySelector
   beforeEach(() => {
@@ -49,7 +48,7 @@ describe('Story.isReady', () => {
     jest.mock('@sx/utils/sleep', () => jest.fn().mockResolvedValue(undefined))
 
     document.querySelector = jest.fn((selector) => {
-      if (selector === '.story-name') {
+      if (selector === '.story-name' || selector === '.historical-change-v2') {
         return {}
       }
       else if (selector === '#story-description-v2') {
@@ -73,12 +72,13 @@ describe('Story.isReady', () => {
 
   it('should keep checking for story title until it is found', async () => {
     document.querySelector = jest.fn().mockReturnValue(null)
-    const result = await Story.isReady()
-    expect(result).toBe(false)
+    await expect(Story.isReady()).rejects.toThrow('Story page did not load in time')
     // eslint-disable-next-line no-magic-numbers
-    expect(document.querySelector).toHaveBeenNthCalledWith(9, '.story-name')
-    // 10 calls to document.querySelector for story title and historical changes, each, plus the initial call
-    const EXPECTED_CALLS = 22
+    expect(document.querySelector).toHaveBeenNthCalledWith(7, '.story-name')
+    expect(document.querySelector).toHaveBeenNthCalledWith(8, '#story-description-v2')
+    expect(document.querySelector).toHaveBeenNthCalledWith(9, '.historical-change-v2')
+    // 20 calls to document.querySelector for story title, description, and historical changes, each, plus the initial call
+    const EXPECTED_CALLS = 63
     expect(document.querySelector).toHaveBeenCalledTimes(EXPECTED_CALLS)
   })
 })


### PR DESCRIPTION
## What's Changed
Fixes an issue where development time failed to load on SPA navigation changes

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [x] On SPA navigation
- [x] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
- [x] Add notes to a story
