### PR TITLE
SHA-181: Do not track initialization

### DIFF
--- a/src/js/service-worker/service-worker.ts
+++ b/src/js/service-worker/service-worker.ts
@@ -1,8 +1,5 @@
-import { sendEvent } from '@sx/analytics/event'
 import { handleCommands } from '@sx/service-worker/handlers'
 import checkHost from '@sx/utils/check-host'
-import { getSyncedSetting } from '@sx/utils/get-synced-setting'
-import scope from '@sx/utils/sentry'
 import { Story } from '@sx/utils/story'
 import Workspace from '@sx/workspace/workspace'
 
@@ -10,12 +7,10 @@ import { onInstallAndUpdate } from './on-install-and-update'
 import { SlugManager } from './slug-manager'
 
 
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
 chrome.commands.onCommand.addListener(handleCommands)
 
 chrome.runtime.onInstalled.addListener(onInstallAndUpdate)
 
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
 chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo) {
   if (changeInfo.url && checkHost(changeInfo.url) && changeInfo.url.includes('story')) {
     Workspace.activate()
@@ -25,17 +20,6 @@ chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo) {
       message: 'update',
       url: changeInfo.url
     })
-    const enableTodoistOptions = await getSyncedSetting('enableTodoistOptions', false)
-    if (enableTodoistOptions) {
-      chrome.tabs.sendMessage(tabId, {
-        message: 'initTodos',
-        url: changeInfo.url
-      })
-      sendEvent('init_todos').catch((e) => {
-        console.error('Error sending event:', e)
-        scope.captureException(e)
-      })
-    }
     chrome.tabs.sendMessage(tabId, {
       message: 'initNotes',
       data: await Story.notes(),


### PR DESCRIPTION
## What's Changed
Do not track initialization of todoist buttons

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [x] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [ ] View development time for in progress stories
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] Add notes to a story
