### PR TITLE
SHA-224: Remove Sentry from development

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -8,6 +8,6 @@ module.exports = {
   devtool: 'inline-source-map',
   watch: true,
   plugins: [
-    ...baseConfig.plugins,
+    ...baseConfig.copyConfig
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ process.env.SENTRY_RELEASE = process.env.VERSION
 const Dotenv = require('dotenv-webpack')
 
 
-const copyConfig = new CopyWebpackPlugin({
+export const copyConfig = new CopyWebpackPlugin({
   patterns: [
     { from: './src/manifest.json', to: 'manifest.json' },
     { from: './src/assets', to: 'assets' },


### PR DESCRIPTION
## What's Changed
Remove Sentry issue tracking from development environment

# Tested
- [x] View and Interact with Todoist buttons
  - [ ] View Story page with Todoist disabled
- [x] Use both analyze and break down AI features
  - [ ] With proxy
  - [x] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [ ] On SPA navigation
- [ ] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [x] Add notes to a story
