### PR TITLE
Change "actions" tab to "notes" tab

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -17,7 +17,7 @@
   <span>Error communicating w/ OpenAI. Please try again later.</span>
 </div>
 <div class="tabs tabs-boxed tabs-sm" role="tablist">
-    <a id="actionsTab" role="tab" class="tab tab-active">Actions</a>
+    <a id="notesTab" role="tab" class="tab tab-active">Notes</a>
     <a id="settingsTab" role="tab" class="tab">Settings</a>
     <a id="infoTab" role="tab" class="tab indicator">
         Info

--- a/src/js/popup/popup.ts
+++ b/src/js/popup/popup.ts
@@ -148,22 +148,22 @@ export class Popup {
   }
 
   async popupLoaded(): Promise<void> {
-    const actionsTab = document.getElementById('actionsTab')
+    const notesTab = document.getElementById('notesTab')
     const settingsTab = document.getElementById('settingsTab')
     const infoTab = document.getElementById('infoTab')
     const actionsSection = document.getElementById('actionsSection')
     const settingsSection = document.getElementById('settingsSection')
     const infoSection = document.getElementById('infoSection')
 
-    if (actionsTab === null || settingsTab === null || infoTab === null || actionsSection === null || settingsSection === null || infoSection === null) {
-      throw new Error('actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found')
+    if (notesTab === null || settingsTab === null || infoTab === null || actionsSection === null || settingsSection === null || infoSection === null) {
+      throw new Error('notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found')
     }
 
     await this.updateFromSettings()
 
-    this.setSectionDisplay(actionsTab, actionsSection, [settingsTab, infoTab], [settingsSection, infoSection])
-    this.setSectionDisplay(settingsTab, settingsSection, [actionsTab, infoTab], [actionsSection, infoSection])
-    this.setSectionDisplay(infoTab, infoSection, [actionsTab, settingsTab], [actionsSection, settingsSection])
+    this.setSectionDisplay(notesTab, actionsSection, [settingsTab, infoTab], [settingsSection, infoSection])
+    this.setSectionDisplay(settingsTab, settingsSection, [notesTab, infoTab], [actionsSection, infoSection])
+    this.setSectionDisplay(infoTab, infoSection, [notesTab, settingsTab], [actionsSection, settingsSection])
 
     this.handleNewVersionBadge().catch((e) => {
       console.error(e)

--- a/tests/popup/popup.test.ts
+++ b/tests/popup/popup.test.ts
@@ -317,7 +317,7 @@ describe('popupLoaded', () => {
     popup.handleNewVersionBadge = jest.fn().mockResolvedValue(null)
     await popup.popupLoaded()
 
-    expect(document.getElementById).toHaveBeenCalledWith('actionsTab')
+    expect(document.getElementById).toHaveBeenCalledWith('notesTab')
     expect(document.getElementById).toHaveBeenCalledWith('settingsTab')
     expect(document.getElementById).toHaveBeenCalledWith('infoTab')
     expect(document.getElementById).toHaveBeenCalledWith('versionInfo')
@@ -336,15 +336,15 @@ describe('popupLoaded', () => {
     })
   })
 
-  it('throws and error if actionsTab is not found', async () => {
+  it('throws and error if notesTab is not found', async () => {
     document.getElementById = jest.fn().mockImplementation((id) => {
-      if (id !== 'actionsTab') {
+      if (id !== 'notesTab') {
         return mockElement()
       }
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -356,7 +356,7 @@ describe('popupLoaded', () => {
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -368,7 +368,7 @@ describe('popupLoaded', () => {
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -380,7 +380,7 @@ describe('popupLoaded', () => {
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -392,7 +392,7 @@ describe('popupLoaded', () => {
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -404,7 +404,7 @@ describe('popupLoaded', () => {
       return null
     })
     const popup = new Popup()
-    const expected = 'actionsTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
+    const expected = 'notesTab, settingsTab, infoTab, actionsSection, settingsSection, or infoSection not found'
     await expect(popup.popupLoaded()).rejects.toThrow(expected)
   })
 
@@ -420,7 +420,7 @@ describe('popupLoaded', () => {
     })
 
     await expect(popup.popupLoaded()).rejects.toThrow('versionSpan not found')
-    expect(document.getElementById).toHaveBeenCalledWith('actionsTab')
+    expect(document.getElementById).toHaveBeenCalledWith('notesTab')
     expect(document.getElementById).toHaveBeenCalledWith('settingsTab')
     expect(document.getElementById).toHaveBeenCalledWith('infoTab')
     expect(document.getElementById).toHaveBeenCalledWith('versionInfo')
@@ -440,7 +440,7 @@ describe('popupLoaded', () => {
     popup.handleNewVersionBadge = jest.fn().mockResolvedValue(null)
     await popup.popupLoaded()
 
-    expect(document.getElementById).toHaveBeenCalledWith('actionsTab')
+    expect(document.getElementById).toHaveBeenCalledWith('notesTab')
     expect(document.getElementById).toHaveBeenCalledWith('settingsTab')
     expect(document.getElementById).toHaveBeenCalledWith('infoTab')
     expect(document.getElementById).toHaveBeenCalledWith('versionInfo')


### PR DESCRIPTION
## What's Changed
Changed the copy and references to an "actions tab" to be a "notes tab"

# Tested
- [x] View and Interact with Todoist buttons
  - [x] View Story page with Todoist disabled
- [x] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [x] View development time for in progress stories
  - [x] On page load
  - [x] On SPA navigation
- [x] View cycle time on a completed story
  - [x] On page load
  - [x] On SPA navigation
- [x] Add notes to a story
