### PR TITLE
SHA-207: Add loading state for button and fix SPA navigation

### DIFF
--- a/src/js/ai/labels/content-script.ts
+++ b/src/js/ai/labels/content-script.ts
@@ -1,4 +1,5 @@
 import { AiProcessMessage } from '@sx/analyze/types/AiProcessMessage'
+import { Story } from '@sx/utils/story'
 
 
 class LabelsContentScript {
@@ -8,8 +9,14 @@ class LabelsContentScript {
       await chrome.action.openPopup()
       return
     }
+    const button = document.querySelector('[data-assistant="add-labels"]')
+    if (!button) {
+      throw new Error('Could not find button')
+    }
+    button.textContent = 'Adding labels...'
     const message: AiProcessMessage = <AiProcessMessage>{ action: 'addLabels' }
-    chrome.runtime.sendMessage(message)
+    await chrome.runtime.sendMessage(message)
+    button.textContent = 'Auto Add Labels...'
   }
 
   static async isAuthenticated(): Promise<boolean> {
@@ -33,6 +40,7 @@ class LabelsContentScript {
     const newButton = document.createElement('button')
     const isAuthenticated = await this.isAuthenticated()
     newButton.className = isAuthenticated ? 'add-labels action micro' : 'micro action'
+    newButton.dataset.assistant = 'add-labels'
     newButton.style.marginTop = '5px'
     newButton.dataset.tooltip = isAuthenticated ? 'Use AI to add relevant labels' : 'Please authenticate w/ Shortcut Assistant to use this feature'
     newButton.addEventListener('click', LabelsContentScript.onClick)
@@ -43,6 +51,7 @@ class LabelsContentScript {
   static async init(): Promise<void> {
     const featureEnabled = process.env.NEW_AI_FEATURES_ENABLED
     if (featureEnabled === 'true') {
+      await Story.isReady()
       await this.addButton()
     }
   }

--- a/src/js/content-scripts.ts
+++ b/src/js/content-scripts.ts
@@ -48,6 +48,7 @@ export async function handleMessage(request: { message: string, url: string }): 
     await analyzeStoryDescription(activeTabUrl)
   }
   if (request.message === 'update') {
+    await Story.isReady()
     DevelopmentTime.set().catch(logError)
     CycleTime.set().catch(logError)
     LabelsContentScript.init().catch(logError)


### PR DESCRIPTION
## What's Changed
- Add loading state for AI Labels and fix issue where button would not appear after SPA navigation

# Tested
- [ ] View and Interact with Todoist buttons
  - [ ] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [ ] With proxy
  - [ ] Without proxy
- [ ] View development time for in progress stories
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] Add notes to a story
