### PR TITLE
SHA-270 Fix estimate shortcut

### DIFF
--- a/src/js/keyboard-shortcuts/change-estimate.ts
+++ b/src/js/keyboard-shortcuts/change-estimate.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/require-await
 async function changeEstimate(): Promise<void> {
   chrome.runtime.sendMessage({ action: 'sendEvent', data: { eventName: 'change_estimate' } })
-  const dropdown: HTMLElement | null = document.querySelector('.estimate-content')
+  const dropdown: HTMLElement | null = document.querySelector('.story-points')
   if (!dropdown) {
     console.error('The estimate dropdown was not found.')
     return
@@ -21,20 +21,21 @@ async function setEstimate(event: KeyboardEvent): Promise<void> {
   if (!key.match(/^\d+$/)) {
     return
   }
-  const estimatesDropdown: HTMLDivElement | null = document.querySelector('.apply-on-click')
-  if (!estimatesDropdown) {
+  const estimatesList: HTMLUListElement | null = document.querySelector('.react-multiselect-list')
+  if (!estimatesList) {
     console.error('The estimates dropdown was not found.')
     return
   }
-  const estimates: NodeListOf<HTMLDivElement> = estimatesDropdown.querySelectorAll('.focusable')
-  estimates.forEach((div) => {
-    if (div.innerText.includes(`${key} points`)) {
-      div.click()
-    }
-    else {
-      console.error('The estimate was not found.')
-    }
+  const options: NodeListOf<HTMLLIElement> = estimatesList.querySelectorAll('li[role="option"]')
+  const matchingOption = Array.from(options).find((option) => {
+    const optionText = option.innerText.replace(/ /g, ' ').trim()
+    return optionText === `${key} Points`
   })
+  if (!matchingOption) {
+    console.error('The estimate was not found.')
+    return
+  }
+  matchingOption.click()
 }
 
 export default changeEstimate

--- a/src/js/keyboard-shortcuts/change-estimate.ts
+++ b/src/js/keyboard-shortcuts/change-estimate.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/require-await
 async function changeEstimate(): Promise<void> {
   chrome.runtime.sendMessage({ action: 'sendEvent', data: { eventName: 'change_estimate' } })
-  const dropdown: HTMLElement | null = document.querySelector('#story-dialog-estimate-dropdown')
+  const dropdown: HTMLElement | null = document.querySelector('.estimate-content')
   if (!dropdown) {
     console.error('The estimate dropdown was not found.')
     return

--- a/src/js/keyboard-shortcuts/change-estimate.ts
+++ b/src/js/keyboard-shortcuts/change-estimate.ts
@@ -28,7 +28,7 @@ async function setEstimate(event: KeyboardEvent): Promise<void> {
   }
   const options: NodeListOf<HTMLLIElement> = estimatesList.querySelectorAll('li[role="option"]')
   const matchingOption = Array.from(options).find((option) => {
-    const optionText = option.innerText.replace(/ /g, ' ').trim()
+    const optionText = option.innerText.replace(/\u00A0/g, ' ').trim()
     return optionText === `${key} Points`
   })
   if (!matchingOption) {

--- a/src/react/client/components/drawers/settings/google-auth-section.tsx
+++ b/src/react/client/components/drawers/settings/google-auth-section.tsx
@@ -81,7 +81,7 @@ function GoogleAuthSection({ onAuthStatusChange }: GoogleAuthSectionProps): Reac
         {buttonText}
       </Button>
       <p className="text-muted-foreground text-xs">
-        We need to verify your Google account before enabling advanced features. This may require logging in on Chrome.
+        We need to verify your Google account before enabling advanced features. This may require logging in on Chrome (Brave, Dia, etc may not work).
       </p>
     </div>
   )

--- a/tests/js/keyboard-shortcuts/change-estimate.test.ts
+++ b/tests/js/keyboard-shortcuts/change-estimate.test.ts
@@ -66,28 +66,60 @@ describe('set estimate', () => {
   })
 
   it('should click on the estimate if it is found', async () => {
-    const mockDiv = { click: jest.fn(), innerText: '1 points' } as unknown as MockedElement
-    const mockQuerySelector = jest.fn().mockReturnValue([mockDiv])
-    const value = { querySelectorAll: mockQuerySelector } as unknown as Element
+    const mockOption = { click: jest.fn(), innerText: '1 Points' } as unknown as MockedElement
+    const mockQuerySelectorAll = jest.fn().mockReturnValue([mockOption])
+    const value = { querySelectorAll: mockQuerySelectorAll } as unknown as Element
     jest.spyOn(document, 'querySelector').mockReturnValueOnce(value)
 
     const event = { key: '1' } as unknown as KeyboardEvent
 
     await setEstimate(event)
 
-    expect(mockDiv.click).toHaveBeenCalled()
+    expect(mockQuerySelectorAll).toHaveBeenCalledWith('li[role="option"]')
+    expect(mockOption.click).toHaveBeenCalled()
+  })
+
+  it('should match the correct estimate among several options', async () => {
+    const mockOptions = ['0 Points', '1 Points', '2 Points'].map((innerText) => {
+      return { click: jest.fn(), innerText } as unknown as MockedElement
+    })
+    const mockQuerySelectorAll = jest.fn().mockReturnValue(mockOptions)
+    const value = { querySelectorAll: mockQuerySelectorAll } as unknown as Element
+    jest.spyOn(document, 'querySelector').mockReturnValueOnce(value)
+
+    const event = { key: '2' } as unknown as KeyboardEvent
+
+    await setEstimate(event)
+
+    expect(mockOptions[2].click).toHaveBeenCalled()
+    expect(mockOptions[0].click).not.toHaveBeenCalled()
+    expect(mockOptions[1].click).not.toHaveBeenCalled()
+  })
+
+  it('should normalize non-breaking spaces in the option text', async () => {
+    const mockOption = { click: jest.fn(), innerText: '8 Points' } as unknown as MockedElement
+    const mockQuerySelectorAll = jest.fn().mockReturnValue([mockOption])
+    const value = { querySelectorAll: mockQuerySelectorAll } as unknown as Element
+    jest.spyOn(document, 'querySelector').mockReturnValueOnce(value)
+
+    const event = { key: '8' } as unknown as KeyboardEvent
+
+    await setEstimate(event)
+
+    expect(mockOption.click).toHaveBeenCalled()
   })
 
   it('should log an error if the estimate is not found', async () => {
-    const mockDiv = { click: jest.fn(), innerText: '2 points' } as unknown as MockedElement
-    const mockQuerySelector = jest.fn().mockReturnValue([mockDiv])
-    const value = { querySelectorAll: mockQuerySelector } as unknown as Element
+    const mockOption = { click: jest.fn(), innerText: '2 Points' } as unknown as MockedElement
+    const mockQuerySelectorAll = jest.fn().mockReturnValue([mockOption])
+    const value = { querySelectorAll: mockQuerySelectorAll } as unknown as Element
     jest.spyOn(document, 'querySelector').mockReturnValueOnce(value)
 
     const event = { key: '1' } as unknown as KeyboardEvent
 
     await setEstimate(event)
 
+    expect(mockOption.click).not.toHaveBeenCalled()
     expect(console.error).toHaveBeenCalledWith('The estimate was not found.')
   })
 })

--- a/tests/react/client/components/drawers/settings/google-auth-section.test.tsx
+++ b/tests/react/client/components/drawers/settings/google-auth-section.test.tsx
@@ -47,7 +47,7 @@ describe('GoogleAuthSection', function testGoogleAuthSectionSuite() {
 
   it('renders the authentication description', function testRendersDescription() {
     setup()
-    expect(screen.getByText('We need to verify your Google account before enabling advanced features. This may require logging in on Chrome.')).toBeInTheDocument()
+    expect(screen.getByText('We need to verify your Google account before enabling advanced features. This may require logging in on Chrome (Brave, Dia, etc may not work).')).toBeInTheDocument()
   })
 
   it('displays "Login with Google" text initially', function testLoginButtonText() {


### PR DESCRIPTION
## What's Changed

# Tested
- [ ] View and Interact with Todoist buttons
  - [ ] View Story page with Todoist disabled
- [x] Use both analyze and break down AI features
  - [x] With proxy
  - [ ] Without proxy
- [ ] View development time for in progress stories
  - [ ] On page load
  - [ ] On SPA navigation
- [x] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] Add notes to a story


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed estimate selection so keyboard shortcuts continue working with the updated estimate dropdown.

* **Documentation**
  * Expanded Google sign-in guidance to clarify that Chrome may be required and some browsers may not be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->